### PR TITLE
Adding DataStoreService scijava service

### DIFF
--- a/src/main/java/cz/it4i/fiji/datastore/service/DataStoreConnection.java
+++ b/src/main/java/cz/it4i/fiji/datastore/service/DataStoreConnection.java
@@ -1,0 +1,57 @@
+package cz.it4i.fiji.datastore.service;
+
+import java.util.Date;
+
+/**
+ * Represents a recently opened connection (with its endpoint) and its validity time window.
+ */
+public class DataStoreConnection {
+
+	public DataStoreConnection(final String datasetServerURL, final long withThisTimeout)
+	{
+		this.datasetServerURL = datasetServerURL;
+		this.createdWithThisTimeout = withThisTimeout;
+	}
+
+	final String datasetServerURL;
+	final long createdWithThisTimeout;
+
+	private long estEndOfLifeTimepoint;
+	final private Date datePrinter = new Date();
+
+	public long timeWhenServerCloses() {
+		return estEndOfLifeTimepoint;
+	}
+
+	public boolean willServerCloseAfter(final long periodOfTime) {
+		return System.currentTimeMillis()+periodOfTime > estEndOfLifeTimepoint;
+	}
+
+	public void serverIsUsedNow() {
+		estEndOfLifeTimepoint = System.currentTimeMillis() + createdWithThisTimeout;
+	}
+
+
+	@Override
+	public String toString() {
+		datePrinter.setTime(estEndOfLifeTimepoint);
+		return datasetServerURL+" (with timeouts of "
+				+(createdWithThisTimeout/1000)+" seconds; closes likely at "
+				+datePrinter+")";
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (o == null || o.getClass() != this.getClass()) return false;
+
+		return datasetServerURL.equals( ((DataStoreConnection)o).datasetServerURL );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return datasetServerURL.hashCode();
+	}
+}

--- a/src/main/java/cz/it4i/fiji/datastore/service/DataStoreRequest.java
+++ b/src/main/java/cz/it4i/fiji/datastore/service/DataStoreRequest.java
@@ -1,0 +1,91 @@
+package cz.it4i.fiji.datastore.service;
+
+/**
+ * Collects all data that together form exactly one request to start up a dedicated DatasetServer.
+ */
+public class DataStoreRequest {
+	//cannot create without initialization, there's no other c'tor
+	public DataStoreRequest(final String URLwithPort, final String datasetUUID,
+	                        final int rx, final int ry, final int rz,
+	                        final String version, final String accessRegime, final int timeout)
+	{
+		reUseFor(URLwithPort,datasetUUID, rx,ry,rz, version,accessRegime,timeout);
+	}
+
+	//completely renew
+	public void reUseFor(final String URLwithPort, final String datasetUUID,
+	                     final int rx, final int ry, final int rz,
+	                     final String version, final String accessRegime, final int timeout)
+	{
+		this.URLwithPort = URLwithPort;
+		this.datasetUUID = datasetUUID;
+		this.rx = rx;
+		this.ry = ry;
+		this.rz = rz;
+		this.version = version;
+		this.accessRegime = accessRegime;
+		this.timeout = timeout;
+	}
+
+	//partially renew
+	public void reUseFor(final int rx, final int ry, final int rz,
+	                     final String version, final String accessRegime, final int timeout)
+	{
+		reUseFor(URLwithPort,datasetUUID, rx,ry,rz, version,accessRegime,timeout);
+	}
+
+	private String URLwithPort;
+	private String datasetUUID;
+	private int rx,ry,rz;
+	private String version;
+	private String accessRegime;
+	private int timeout;
+
+	public long getTimeout()
+	{
+		return timeout;
+	}
+
+	public String createRequestURL()
+	{
+		return createRequestURL(URLwithPort,datasetUUID, rx,ry,rz, version,accessRegime,timeout);
+	}
+
+	static
+	public String createRequestURL(final String URLwithPort, final String datasetUUID,
+	                     final int rx, final int ry, final int rz,
+	                     final String version, final String accessRegime, final int timeout)
+	{
+		return "http://"+URLwithPort+"/datasets/"+datasetUUID+"/"
+				+rx+"/"+ry+"/"+rz+"/"+version+"/"+accessRegime+"?timeout="+timeout;
+	}
+
+
+	@Override
+	public String toString() {
+		return createRequestURL();
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (o == null || o.getClass() != this.getClass()) return false;
+
+		final DataStoreRequest dsr = (DataStoreRequest)o;
+		if (! dsr.URLwithPort.equals(URLwithPort)) return false;
+		if (! dsr.datasetUUID.equals(datasetUUID)) return false;
+		if (dsr.rx != rx || dsr.ry != ry || dsr.rz != rz) return false;
+		if (! dsr.version.equals(version)) return false;
+		if (! dsr.accessRegime.equals(accessRegime)) return false;
+		//NB: timeouts are irrelevant here, they ain't deciding what content will be served
+		return true;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return URLwithPort.hashCode() + datasetUUID.hashCode() + 7*rx + 5*ry + 3*rz
+				+ version.hashCode() + accessRegime.hashCode();
+	}
+}

--- a/src/main/java/cz/it4i/fiji/datastore/service/DataStoreService.java
+++ b/src/main/java/cz/it4i/fiji/datastore/service/DataStoreService.java
@@ -1,0 +1,106 @@
+package cz.it4i.fiji.datastore.service;
+
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.service.AbstractService;
+import org.scijava.service.SciJavaService;
+import org.scijava.service.Service;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Plugin(type = Service.class)
+public class DataStoreService extends AbstractService implements SciJavaService
+{
+	/**
+	 * if the estimated connection ends within this period from the
+	 * current moment, the system will rather request opening a new
+	 * connection than pointing the user onto the existing one (which
+	 * may not be there by the time user actually conducts the request)
+	 */
+	public int uncertaintyWindowMiliSeconds = 5000;
+
+	private static final int PREFERRED_MAX_STORED_SERVICES = 50;
+	private final Map<DataStoreRequest,DataStoreConnection> knownServices = new HashMap<>(PREFERRED_MAX_STORED_SERVICES);
+
+	public String getActiveServingUrl(final DataStoreRequest request)
+	throws IOException
+	{
+		DataStoreConnection connection = knownServices.getOrDefault(request, null);
+
+		//a "dying" connection?  (an existing connection that is about to timeout soon)
+		if (connection != null && connection.willServerCloseAfter(uncertaintyWindowMiliSeconds))
+		{
+			knownServices.remove(request);
+			connection = null;
+		}
+
+		//shall we open a new connection?
+		if (connection == null) {
+			connection = new DataStoreConnection(
+					requestService( request.createRequestURL() ), request.getTimeout() );
+			knownServices.put(request, connection);
+
+			//try to clean up...
+			if (knownServices.size() > PREFERRED_MAX_STORED_SERVICES)
+				proneInactiveServices();
+		}
+
+		//hypothetically "reset" the timeout of the service
+		connection.serverIsUsedNow();
+
+		return connection.datasetServerURL;
+	}
+
+	public void proneInactiveServices()
+	{
+		final long criticalTime = System.currentTimeMillis() + uncertaintyWindowMiliSeconds;
+		knownServices.entrySet().removeIf(e -> e.getValue().timeWhenServerCloses() < criticalTime);
+	}
+
+	public void serverIsUsedNow(final DataStoreRequest request)
+	{
+		final DataStoreConnection conn = knownServices.getOrDefault(request, null);
+		if (conn != null) conn.serverIsUsedNow();
+	}
+
+	final Date datePrinter = new Date();
+
+	@Override
+	public String toString()
+	{
+		final long now = System.currentTimeMillis();
+		datePrinter.setTime(now);
+
+		final StringBuilder sb = new StringBuilder("Known connections at ");
+		sb.append(datePrinter).append(":\n");
+		for (DataStoreRequest req : knownServices.keySet())
+		{
+			final DataStoreConnection conn = knownServices.get(req);
+			sb.append("  ").append(req).append("\n  -> ").append(conn);
+
+			final long closingTime = conn.timeWhenServerCloses() - uncertaintyWindowMiliSeconds;
+			if (now > closingTime)
+				sb.append(" is likely already closed by now\n");
+			else
+				sb.append(" will likely be opened for at least ")
+						.append((closingTime-now)/1000).append(" seconds\n");
+		}
+		return sb.toString();
+	}
+
+
+	static
+	public String requestService(final String requestFormattedUrl)
+	throws IOException
+	{
+		//connect to get the new URL for the blocks-server itself
+		final URLConnection connection = new URL(requestFormattedUrl).openConnection();
+		connection.getInputStream(); //this enables access to the redirected URL
+		return connection.getURL().toString();
+	}
+}

--- a/src/main/java/cz/it4i/fiji/legacy/QueryDatasetServiceStatus.java
+++ b/src/main/java/cz/it4i/fiji/legacy/QueryDatasetServiceStatus.java
@@ -1,0 +1,21 @@
+package cz.it4i.fiji.legacy;
+
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.log.LogService;
+import cz.it4i.fiji.datastore.service.DataStoreService;
+
+@Plugin(type = Command.class, headless = false, menuPath = "Plugins>HPC DataStore>Query>DatasetService cache")
+public class QueryDatasetServiceStatus implements Command {
+	@Parameter
+	public LogService mainLogger;
+
+	@Parameter
+	public DataStoreService dataStoreService;
+
+	@Override
+	public void run() {
+		mainLogger.info( dataStoreService );
+	}
+}

--- a/src/main/java/cz/it4i/fiji/legacy/ReadFullImage.java
+++ b/src/main/java/cz/it4i/fiji/legacy/ReadFullImage.java
@@ -7,6 +7,7 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import static cz.it4i.fiji.legacy.common.ImagePlusTransferrer.createResStr;
+import cz.it4i.fiji.datastore.service.DataStoreService;
 import cz.it4i.fiji.legacy.common.ImagePlusTransferrer;
 import cz.it4i.fiji.rest.util.DatasetInfo;
 import org.scijava.Context;
@@ -105,7 +106,7 @@ public class ReadFullImage implements Command {
 	static class LocalReader extends ImagePlusTransferrer {
 		/** intended for use in solo (without a valid scijava context) application */
 		LocalReader() {
-			final Context ctx = new Context(LogService.class);
+			final Context ctx = new Context(LogService.class,DataStoreService.class);
 			mainLogger = ctx.getService(LogService.class);
 		}
 
@@ -135,6 +136,9 @@ public class ReadFullImage implements Command {
 			this.maxY=Integer.MAX_VALUE;
 			this.minZ=0;
 			this.maxZ=Integer.MAX_VALUE;
+			this.dataStoreService = getContext().getService(DataStoreService.class);
+			if (this.dataStoreService == null)
+				throw new RuntimeException("Missing DataStoreService (is null) when reading full image.");
 
 			myLogger = mainLogger.subLogger("HPC LegacyImage Read", verboseLog ? LogLevel.INFO : LogLevel.ERROR);
 			myLogger.info("entered init with this state: "+reportCurrentSettings());

--- a/src/main/java/cz/it4i/fiji/legacy/WriteFullImage.java
+++ b/src/main/java/cz/it4i/fiji/legacy/WriteFullImage.java
@@ -6,6 +6,7 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 import static cz.it4i.fiji.legacy.common.ImagePlusTransferrer.createResStr;
+import cz.it4i.fiji.datastore.service.DataStoreService;
 import cz.it4i.fiji.legacy.common.ImagePlusTransferrer;
 import cz.it4i.fiji.rest.util.DatasetInfo;
 import net.imglib2.img.Img;
@@ -107,7 +108,7 @@ public class WriteFullImage implements Command {
 	static class LocalWriter extends ImagePlusTransferrer {
 		/** intended for use in solo (without a valid scijava context) application */
 		LocalWriter() {
-			final Context ctx = new Context(LogService.class);
+			final Context ctx = new Context(LogService.class,DataStoreService.class);
 			mainLogger = ctx.getService(LogService.class);
 		}
 
@@ -144,6 +145,9 @@ public class WriteFullImage implements Command {
 			this.maxY=Integer.MAX_VALUE;
 			this.minZ=0;
 			this.maxZ=Integer.MAX_VALUE;
+			this.dataStoreService = getContext().getService(DataStoreService.class);
+			if (this.dataStoreService == null)
+				throw new RuntimeException("Missing DataStoreService (is null) when writing full image.");
 
 			myLogger = mainLogger.subLogger("HPC LegacyImage Write", verboseLog ? LogLevel.INFO : LogLevel.ERROR);
 			myLogger.info("entered init with this state: "+reportCurrentSettings());


### PR DESCRIPTION
Since the main server (the registerService) is typically starting dedicated server (datasetServer) for every data down-/up-load request, the client either need to request an opening of a fresh new server for every new image transfer, or the client needs to remember what servers has been opened recently and try to reuse them (if they fit the request). This service does precisely the later. Example:

```
@Parameter
public DataStoreService dataStoreService;

//wrap the request into a structure...
DataStoreRequest req = new DataStoreRequest(URL,datasetID,
				currentResLevel.resolutions.get(0), currentResLevel.resolutions.get(1),
				currentResLevel.resolutions.get(2), versionAsStr, accessRegime, timeout);
//myLogger.info(req);

//asks for a datasetServer to serve this request, either a new one or re-use some if there is a good chance
//that the server will be there in the following dataStoreService.uncertaintyWindowMiliSeconds miliseconds
String urlOfDatasetServer = dataStoreService.getActiveServingUrl(req);

//now talk to the urlOfDatasetServer to up/download blocks, and notify the service about this communication
dataStoreService.serverIsUsedNow(req);
```